### PR TITLE
Use a player's Discord Nickname, rather than their handle

### DIFF
--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -870,7 +870,7 @@ class Pokemon(commands.Cog):
         ):
             embed = discord.Embed()
             embed.color = 0xF44336
-            embed.title = f"Congratulations {ctx.author.name}!"
+            embed.title = f"Congratulations {ctx.author.display_name}!"
 
             name = str(pokemon.species)
 

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -456,7 +456,7 @@ class Shop(commands.Cog):
         if "evolve" in item.action:
             embed = discord.Embed()
             embed.color = 0xF44336
-            embed.title = f"Congratulations {ctx.author.name}!"
+            embed.title = f"Congratulations {ctx.author.display_name}!"
 
             name = str(pokemon.species)
 
@@ -493,7 +493,7 @@ class Shop(commands.Cog):
 
             embed = discord.Embed()
             embed.color = 0xF44336
-            embed.title = f"Congratulations {ctx.author.name}!"
+            embed.title = f"Congratulations {ctx.author.display_name}!"
 
             name = str(pokemon.species)
 
@@ -583,7 +583,7 @@ class Shop(commands.Cog):
                 ):
                     embed = discord.Embed()
                     embed.color = 0xF44336
-                    embed.title = f"Congratulations {ctx.author.name}!"
+                    embed.title = f"Congratulations {ctx.author.display_name}!"
 
                     name = str(pokemon.species)
 

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -99,7 +99,7 @@ class Spawning(commands.Cog):
                     }
                     embed = discord.Embed()
                     embed.color = 0xF44336
-                    embed.title = f"Congratulations {message.author.name}!"
+                    embed.title = f"Congratulations {message.author.display_name}!"
 
                     name = str(pokemon.species)
 

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -138,7 +138,7 @@ class Trading(commands.Cog):
                             ):
                                 evo_embed = discord.Embed()
                                 evo_embed.color = 0xF44336
-                                evo_embed.title = f"Congratulations {omem.name}!"
+                                evo_embed.title = f"Congratulations {omem.display_name}!"
 
                                 name = str(pokemon.species)
 


### PR DESCRIPTION
This PR converts references of `discord.Member.name` to `discord.Member.display_name`, which means server-specific nicknames will be used in messages, rather than their underlying handle.

Current Behaviour:
![image](https://user-images.githubusercontent.com/194254/88445491-5e29b880-ce66-11ea-868e-f22e6c26771b.png)

New Behaviour:
![image](https://user-images.githubusercontent.com/194254/88446116-b82c7d00-ce6a-11ea-9ef6-23573183d26c.png)
