### PR TITLE
Levelupcheck is performed with the old XP value before gaining XP, allowing XP overflow

### DIFF
--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -79,18 +79,20 @@ class Spawning(commands.Cog):
 
                 # TODO this stuff here needs to be refactored
 
-                if pokemon.level < 100 and pokemon.xp <= pokemon.max_xp:
+                if pokemon.level < 100 and pokemon.xp < pokemon.max_xp:
                     xp_inc = random.randint(10, 40)
 
                     if member.boost_active or message.guild.id == 716390832034414685:
                         xp_inc *= 2
+
+                    pokemon.xp += xp_inc
 
                     await self.db.update_member(
                         message.author,
                         {"$inc": {f"pokemon.{member.selected}.xp": xp_inc},},
                     )
 
-                if pokemon.xp > pokemon.max_xp and pokemon.level < 100:
+                if pokemon.xp >= pokemon.max_xp and pokemon.level < 100:
                     update = {
                         "$set": {
                             f"pokemon.{member.selected}.xp": 0,


### PR DESCRIPTION
In cogs/spawning.py:80ff the XP of the selected pokemon are increased only in the database but afterwards the check for possible levelup is performed with the old XP value before increasing. This leads to XP overflowing the max XP and the level up performed one message too late. Ideally the level up should happen in the moment the XP reaches or exceeds the max XP.
![Poketwo-XP-issue7](https://user-images.githubusercontent.com/28844868/88783330-ebcf1600-d18e-11ea-8577-67ddad71ee2d.png)