### PR TITLE
Handle BadArgument and bot-wide ClientSession

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,12 +1,13 @@
 import asyncio
 from importlib import reload
 
+import config
 import discord
 import uvloop
+from aiohttp import ClientSession
 from discord.ext import commands
 
 import cogs
-import config
 import helpers
 
 DEFAULT_DISABLED_MESSAGE = (
@@ -36,6 +37,7 @@ class ClusterBot(commands.AutoShardedBot):
 
     def __init__(self, **kwargs):
         self.pipe = kwargs.pop("pipe")
+        self.session = ClientSession()
         self.cluster_name = kwargs.pop("cluster_name")
         self.cluster_idx = kwargs.pop("cluster_idx")
         self.config = config

--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -3,7 +3,6 @@ import sys
 import traceback
 from datetime import datetime, timedelta
 
-import aiohttp
 import discord
 from discord.ext import commands, flags, tasks
 
@@ -253,10 +252,9 @@ class Bot(commands.Cog):
         result = await self.get_stats()
         headers = {"Authorization": self.bot.config.DBL_TOKEN}
         data = {"server_count": result["servers"], "shard_count": result["shards"]}
-        async with aiohttp.ClientSession(headers=headers) as sess:
-            await sess.post(
-                f"https://top.gg/api/bots/{self.bot.user.id}/stats", data=data
-            )
+        await self.bot.session.post(
+            f"https://top.gg/api/bots/{self.bot.user.id}/stats", data=data, headers=headers
+        )
 
     @tasks.loop(seconds=15)
     async def remind_votes(self):

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -394,6 +394,13 @@ class Market(commands.Cog):
 
         await ctx.send(embed=embed)
 
+    @info.error
+    @buy.error
+    @remove.error
+    async def handle_bad_argument(self, ctx, error):  # Send a more helpful message here
+        if isinstance(error, commands.BadArgument):
+            await ctx.send("You've gotta give me a number for that!")
+
 
 def setup(bot):
     bot.add_cog(Market(bot))

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -3,7 +3,6 @@ import random
 import typing
 from datetime import datetime, timedelta
 
-import aiohttp
 import discord
 import humanfriendly
 from data import models
@@ -27,11 +26,10 @@ class Shop(commands.Cog):
 
     @tasks.loop(minutes=5)
     async def check_weekend(self):
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://discordbots.org/api/weekend") as r:
-                if r.status == 200:
-                    js = await r.json()
-                    self.weekend = js["is_weekend"]
+        async with self.bot.session.get("https://discordbots.org/api/weekend") as r:
+            if r.status == 200:
+                js = await r.json()
+                self.weekend = js["is_weekend"]
 
     @property
     def month_number(self):

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -7,7 +7,6 @@ import traceback
 from collections import defaultdict
 from datetime import datetime
 
-import aiohttp
 import discord
 import humanfriendly
 from data import models
@@ -262,28 +261,27 @@ class Spawning(commands.Cog):
             f"Guess the pokémon and type `{prefix}catch <pokémon>` to catch it!"
         )
 
-        async with aiohttp.ClientSession() as session:
-            url = f"https://server.poketwo.net/image?species={species.id}&time="
-            url += "day" if guild.is_day else "night"
-            try:
-                async with session.get(url) as resp:
-                    if resp.status == 200:
-                        arr = await self.bot.loop.run_in_executor(
-                            None, write_fp, await resp.read()
-                        )
-                        image = discord.File(arr, filename="pokemon.jpg")
-                        embed.set_image(url="attachment://pokemon.jpg")
-                    else:
-                        raise Exception("Server error")
-            except Exception as error:
-                self.bot.log.error("Couldn't fetch spawn image")
-                traceback.print_exception(
-                    type(error), error, error.__traceback__, file=sys.stderr
-                )
-                image = discord.File(
-                    f"data/images/{species.id}.png", filename="pokemon.png"
-                )
-                embed.set_image(url="attachment://pokemon.png")
+        url = f"https://server.poketwo.net/image?species={species.id}&time="
+        url += "day" if guild.is_day else "night"
+        try:
+            async with self.bot.session.get(url) as resp:
+                if resp.status == 200:
+                    arr = await self.bot.loop.run_in_executor(
+                        None, write_fp, await resp.read()
+                    )
+                    image = discord.File(arr, filename="pokemon.jpg")
+                    embed.set_image(url="attachment://pokemon.jpg")
+                else:
+                    raise Exception("Server error")
+        except Exception as error:
+            self.bot.log.error("Couldn't fetch spawn image")
+            traceback.print_exception(
+                type(error), error, error.__traceback__, file=sys.stderr
+            )
+            image = discord.File(
+                f"data/images/{species.id}.png", filename="pokemon.png"
+            )
+            embed.set_image(url="attachment://pokemon.png")
 
         if incense:
             timespan = incense - datetime.utcnow()


### PR DESCRIPTION
This pull request does 2 things:
- Rather than creating a new `aiohttp.ClientSession` each time a web request is made, a `ClientSession` is created as a bot-wide variable upon bot startup, allowing it to be reused across all requests.
- Implemented the local error handler for `commands.BadArgument` that I suggested [here](https://github.com/oliver-ni/poketwo/issues/65)