### PR TITLE
Enhancement: Accept caps. in Custom Prefixes

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -182,6 +182,7 @@ class Bot(commands.Cog):
             if self.bot.prefixes[guild.id] is not None:
                 return [
                     self.bot.prefixes[guild.id],
+                    self.bot.prefixes[guild.id].capitalize(),
                     self.bot.user.mention + " ",
                     self.bot.user.mention[:2] + "!" + self.bot.user.mention[2:] + " ",
                 ]


### PR DESCRIPTION
Per community suggestion by Wenoh#6969 in post https://discord.com/channels/716390832034414685/719100172491161640/793692136784527370 , enables bot acceptance of capitalized (first letter) custom server prefixes to enhance typing experience of mobile players.

**Affected Users:** Servers with custom prefixes, since default prefixes p! and P! are both currently accepted.
**Advantage:** On mobile, first letters are automatically capitalized, giving mobile players disadvantage in catching. This PR solves this issue. 
**Drawback:** limits available (free) bot prefixes on server, **might cause bot interference** in some servers with lower and uppercase commands for different bots.

Due to the **potential drawbacks** above, please determine if this enhancement is a **needed** feature and if an update announcement in OS is needed (for players to adjust accordingly) before merge.

Thank you.