### PR TITLE
Auctions: Disable Lowering Start past Bid Increment

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -288,6 +288,10 @@ class Auctions(commands.Cog):
             return await ctx.send(
                 "You may only lower the starting bid, not increase it."
             )
+        if auction.bid_increment > new_start:
+            return await ctx.send(
+                "You may not set the new starting bid to a value less than your bid increment."
+            )
 
         guild = await self.bot.mongo.fetch_guild(ctx.guild)
 


### PR DESCRIPTION
Prevent users from circumventing Line 192 in auctions.py. (invalid bid increments)

**Before:** p!a start (id) (time) 888888 888888, then p!a lowerstart (id) 1 lowers start to 1 and keeps increment at 888888

**After:** p!a start (id) (time) 888888 888888, then p!a lowerstart (id) 1 raises "You may not set the new starting bid to a value less than your bid increment."