### PR TITLE
Add check for non-alphanumeric characters in nickname commands

### DIFF
--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -60,6 +60,9 @@ class Pokemon(commands.Cog):
         if len(nickname) > 100:
             return await ctx.send("That nickname is too long.")
 
+        if not nickname.isalnum():
+            return await ctx.send("That nickname contains non-alphanumeric characters.")
+
         if nickname == "reset":
             nickname = None
 
@@ -122,6 +125,9 @@ class Pokemon(commands.Cog):
         # check nick length
         if len(nicknameall) > 100:
             return await ctx.send("That nickname is too long.")
+
+        if not nicknameall.isalnum():
+            return await ctx.send("That nickname contains non-alphanumeric characters.")
 
         # check nick reset
         if nicknameall == "reset":


### PR DESCRIPTION
Closes #87 

Added check about alphanumeric characters to `nickname` and `nickall` commadns.