### PR TITLE
Implemented message edit reprocess

### DIFF
--- a/cogs/bot.py
+++ b/cogs/bot.py
@@ -51,6 +51,10 @@ class Bot(commands.Cog):
             raise commands.CommandOnCooldown(bucket, retry_after)
 
         return True
+    
+    @commands.Cog.listener()
+    async def on_message_edit(self, before, after):
+        await self.bot.process_commands(after)
 
     @commands.Cog.listener()
     async def on_command(self, ctx):


### PR DESCRIPTION
Added a listener to reprocess commands after being edited, instead of having to retype or copy and paste the previous message. This makes it easier to correct small mistakes in Pokémon names with a simple edit.