### PR TITLE
Fixes for market.py and auction.py

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -210,6 +210,16 @@ class Auctions(commands.Cog):
                 "Auctions have not been set up in this server. Have a server administrator do `p!auction channel #channel`."
             )
 
+        member = await self.bot.mongo.fetch_member_info(ctx.author)
+
+        if member.selected_id == pokemon.id:
+            return await ctx.send(
+                f"{pokemon.idx}: You can't auction your selected pokémon!"
+            )
+        
+        if pokemon.favorite:
+            return await ctx.send(f"{pokemon.idx}: You can't auction a favorited pokémon!")
+
         # confirm
 
         await ctx.send(

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -139,6 +139,14 @@ class Market(commands.Cog):
 
         member = await self.bot.mongo.fetch_member_info(ctx.author)
 
+        if member.selected_id == pokemon.id:
+            return await ctx.send(
+                f"{pokemon.idx}: You can't list your selected pokémon!"
+            )
+        
+        if pokemon.favorite:
+            return await ctx.send(f"{pokemon.idx}: You can't list a favorited pokémon!")
+
         # confirm
 
         await ctx.send(


### PR DESCRIPTION
Due to popular community and staff suggestion, disabled listing of **selected** and **favorited** Pokemon in market. 
This fix would:
1. Prevent accidental listing of favorited Pokemons
2. Disallow Pokemon being already favorited when it is bought from market
3. Fix the "You don't have a Pokemon selected" bug reproduced when the selected Pokemon is listed on market.