### PR TITLE
Add ability to evolve multiple Pokémon

### DIFF
--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -949,7 +949,7 @@ class Pokemon(commands.Cog):
     @checks.has_started()
     @commands.guild_only()
     @commands.command(rest_is_raw=True)
-    async def evolve(self, ctx, *, args: commands.Greedy[converters.PokemonConverter]):
+    async def evolve(self, ctx, args: commands.Greedy[converters.PokemonConverter]):
         """Evolve a pokémon if it has reached the target level."""
 
         if not all(pokemon is not None for pokemon in args):

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -967,7 +967,7 @@ class Pokemon(commands.Cog):
             return await ctx.send("You can't evolve more than 30 pokémon at once!")
 
         for pokemon in args:
-            name = '{0:n}'.format(pokemon)
+            name = format(pokemon, 'n')
 
             if (evo := pokemon.get_next_evolution(guild.is_day)) is None:
                 return await ctx.send(f"Your {name} can't be evolved!")

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -967,10 +967,7 @@ class Pokemon(commands.Cog):
             return await ctx.send("You can't evolve more than 30 pokémon at once!")
 
         for pokemon in args:
-            name = str(pokemon.species)
-
-            if pokemon.nickname is not None:
-                name += f' "{pokemon.nickname}"'
+            name = '{0:n}'.format(pokemon)
 
             if (evo := pokemon.get_next_evolution(guild.is_day)) is None:
                 return await ctx.send(f"Your {name} can't be evolved!")

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -963,6 +963,9 @@ class Pokemon(commands.Cog):
 
         evolved = []
 
+        if len(args) > 30:
+            return await ctx.send("You can't evolve more than 30 pokémon at once!")
+
         for pokemon in args:
             name = str(pokemon.species)
 
@@ -972,20 +975,17 @@ class Pokemon(commands.Cog):
             if (evo := pokemon.get_next_evolution(guild.is_day)) is None:
                 return await ctx.send(f"Your {name} can't be evolved!")
 
-            if len(pokemon) < 20:
+            if len(args) < 20:
                 embed.add_field(
                     name=f"Your {name} is evolving!",
                     value=f"Your {name} has turned into a {evo}!",
                     inline=True
                 )
 
-            elif len(pokemon) < 30:
+            else:
                 embed.description += f"\n**Your {name} is evolving!**\nYour {name} has turned into a {evo}!"
 
-            else:
-                return await ctx.send("You can't evolve more than 30 pokémon at once!")
-
-            if len(pokemon) == 1:
+            if len(args) == 1:
                 if pokemon.shiny:
                     embed.set_thumbnail(url=evo.shiny_image_url)
                 else:


### PR DESCRIPTION
Adds the ability to evolve multiple Pokémon at once using `commands.Greedy`.

The number of Pokémon is capped at 30, and anything less than 20 Pokémon will be represented as fields, while anything between 20 and 30 will be in the embed description. Thumbnail sprites will only be used when singular Pokémon are evolved.

Resolves #113 