### PR TITLE
A Couple Display Enhancements

### DIFF
--- a/cogs/mongo.py
+++ b/cogs/mongo.py
@@ -81,6 +81,9 @@ class PokemonBase(MixinDocument):
         elif "L" in spec:
             name += f"L{self.level} "
 
+        if "p" in spec:
+            name += f"{self.iv_percentage:.2%} "
+
         if self.bot.sprites.status and "i" in spec:
             sprite = self.bot.sprites.get(self.species.dex_number, shiny=self.shiny)
             name = sprite + " " + name

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -712,7 +712,7 @@ class Pokemon(commands.Cog):
 
         if len(mons) == 1:
             await ctx.send(
-                f'Are you sure you want to **release** your{" ✨" if pokemon.shiny else ""} Level {pokemon.level} {pokemon.iv_percentage * 100:.2f}% {pokemon.species}. No. {pokemon.idx} for 2 pc? \nThis action is irreversible! Type `confirm release {len(mons)}` to confirm.'
+                f'Are you sure you want to **release** your{" ✨" if mons[0].shiny else ""} Level {mons[0].level} {mons[0].iv_percentage * 100:.2f}% {mons[0].species}. No. {mons[0].idx} for 2 pc? \nThis action is irreversible! Type `confirm release {len(mons)}` to confirm.'
             )
         else:
             embed = self.bot.Embed(color=0x9CCFFF)

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -712,14 +712,14 @@ class Pokemon(commands.Cog):
 
         if len(mons) == 1:
             await ctx.send(
-                f'Are you sure you want to **release** your{" ✨" if mons[0].shiny else ""} Level {mons[0].level} {mons[0].iv_percentage * 100:.2f}% {mons[0].species}. No. {mons[0].idx} for 2 pc? [y/N]'
+                f'Are you sure you want to **release** your {mons[0]:spl} No. {mons[0].idx} for 2 pc? [y/N]'
             )
         else:
             embed = self.bot.Embed(color=0x9CCFFF)
             embed.title = f"Are you sure you want to release the following pokémon for {len(mons)*2:,} pc? [y/N]"
 
             embed.description = "\n".join(
-                f'{"✨ " if x.shiny else ""}Level {x.level} {x.iv_percentage * 100:.2f}% {x.species} ({x.idx})' for x in mons
+                f'{x:spl} ({x.idx})' for x in mons
             )
 
             await ctx.send(embed=embed)

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -703,7 +703,7 @@ class Pokemon(commands.Cog):
                 mons.append(pokemon)
 
         if len(args) != len(mons):    
-            await ctx.send(f"Couldn't find/release {len(args)-len(mons)} pokémon in selection!")
+            await ctx.send(f"Couldn't find/release {len(args)-len(mons)} pokémon in this selection!")
 
         # Confirmation msg
 
@@ -712,11 +712,11 @@ class Pokemon(commands.Cog):
 
         if len(mons) == 1:
             await ctx.send(
-                f'Are you sure you want to **release** your{" ✨" if mons[0].shiny else ""} Level {mons[0].level} {mons[0].iv_percentage * 100:.2f}% {mons[0].species}. No. {mons[0].idx} for 2 pc? \nThis action is irreversible! Type `confirm release {len(mons)}` to confirm.'
+                f'Are you sure you want to **release** your{" ✨" if mons[0].shiny else ""} Level {mons[0].level} {mons[0].iv_percentage * 100:.2f}% {mons[0].species}. No. {mons[0].idx} for 2 pc? [y/N]'
             )
         else:
             embed = self.bot.Embed(color=0x9CCFFF)
-            embed.title = f"Are you sure you want to release the following pokémon for {len(mons)*2:,} pc?\nType `confirm release {len(mons)}` to confirm."
+            embed.title = f"Are you sure you want to release the following pokémon for {len(mons)*2:,} pc? [y/N]"
 
             embed.description = "\n".join(
                 f'{"✨ " if x.shiny else ""}Level {x.level} {x.iv_percentage * 100:.2f}% {x.species} ({x.idx})' for x in mons
@@ -730,7 +730,7 @@ class Pokemon(commands.Cog):
         try:
             msg = await self.bot.wait_for("message", timeout=30, check=check)
 
-            if msg.content.lower() != f"confirm release {len(mons)}":
+            if msg.content.lower() != "y":
                 return await ctx.send("Aborted.")
         except asyncio.TimeoutError:
             return await ctx.send("Time's up. Aborted.")


### PR DESCRIPTION
**Main Changes**
1. Display more information during `p!release`.
Added :sparkles:, IV.
Added "Can't find/release (x) Pokemon" message.
2. Require text confirmation (instead of y/n) during `p!release`.
Thank you Sk#4676 for the two suggestions above!
3. Display rarity for rare pokemons in dex.
Thank you Yiqii#6383 for the suggestion above!

**Stylistic Changes**
1. Display custom server prefixes in `p!favoriteall` support message.
Thank you corpsesimp#3949 for the suggestion above!