### PR TITLE
Added Match for Duplicate IV's

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -506,6 +506,12 @@ class Auctions(commands.Cog):
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
 
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)

--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -507,10 +507,10 @@ class Auctions(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -44,6 +44,12 @@ class Market(commands.Cog):
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
 
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -45,10 +45,10 @@ class Market(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -119,10 +119,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -198,7 +198,13 @@ class Pokemon(commands.Cog):
         else:
             await ctx.send(f"Changed nickname to `{nicknameall}` for {num} pokémon.")
 
-    @commands.command(aliases=("favourite","fav",), rest_is_raw=True)
+    @commands.command(
+        aliases=(
+            "favourite",
+            "fav",
+        ),
+        rest_is_raw=True,
+    )
     async def favorite(self, ctx, args: commands.Greedy[converters.PokemonConverter]):
         """Mark a pokémon as a favorite."""
 
@@ -218,19 +224,27 @@ class Pokemon(commands.Cog):
                     name += f' "{pokemon.nickname}"'
 
                 if pokemon.favorite:
-                    messages.append(f"Your level {pokemon.level} {name} is already favorited.\nTo unfavorite a pokemon, please use `p!unfavorite`.")
+                    messages.append(
+                        f"Your level {pokemon.level} {name} is already favorited.\nTo unfavorite a pokemon, please use `p!unfavorite`."
+                    )
                 else:
                     await self.bot.mongo.update_pokemon(
-                    pokemon,
-                    {"$set": {f"favorite": True}},
+                        pokemon,
+                        {"$set": {f"favorite": True}},
                     )
                     messages.append(f"Favorited your level {pokemon.level} {name}.")
-                    
+
             longmsg = "\n".join(messages)
             for i in range(0, len(longmsg), 2000):
                 await ctx.send(longmsg[i : i + 2000])
 
-    @commands.command(aliases=("unfavourite","unfav",), rest_is_raw=True)
+    @commands.command(
+        aliases=(
+            "unfavourite",
+            "unfav",
+        ),
+        rest_is_raw=True,
+    )
     async def unfavorite(self, ctx, args: commands.Greedy[converters.PokemonConverter]):
         """Unfavorite a selected pokemon."""
 
@@ -283,10 +297,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -295,7 +309,13 @@ class Pokemon(commands.Cog):
     # Rename all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.user)
-    @flags.command(aliases=("favouriteall","favall","fa",))
+    @flags.command(
+        aliases=(
+            "favouriteall",
+            "favall",
+            "fa",
+        )
+    )
     async def favoriteall(self, ctx, **flags):
         """Mass favorite selected pokemon."""
 
@@ -303,13 +323,13 @@ class Pokemon(commands.Cog):
 
         if aggregations is None:
             return
-        
+
         # Check pokemon and unfavorited pokemon num
         num = await self.bot.mongo.fetch_pokemon_count(
             ctx.author, aggregations=aggregations
         )
 
-        aggregations.append({"$match":{"pokemon.favorite": {"$ne": True}}})
+        aggregations.append({"$match": {"pokemon.favorite": {"$ne": True}}})
         unfavnum = await self.bot.mongo.fetch_pokemon_count(
             ctx.author, aggregations=aggregations
         )
@@ -317,7 +337,9 @@ class Pokemon(commands.Cog):
         if num == 0:
             return await ctx.send("Found no pokémon matching this search.")
         elif unfavnum == 0:
-            return await ctx.send("Found no unfavorited pokémon within this selection.\nTo mass unfavorite a pokemon, please use `p!unfavoriteall`.")
+            return await ctx.send(
+                "Found no unfavorited pokémon within this selection.\nTo mass unfavorite a pokemon, please use `p!unfavoriteall`."
+            )
 
         # Fetch pokemon list
         pokemon = self.bot.mongo.fetch_pokemon_list(ctx.author, aggregations)
@@ -340,11 +362,13 @@ class Pokemon(commands.Cog):
             return await ctx.send("Time's up. Aborted.")
 
         await self.bot.mongo.db.pokemon.update_many(
-        {"_id": {"$in": [x.id async for x in pokemon]}},
-        {"$set": {"favorite": True}},
+            {"_id": {"$in": [x.id async for x in pokemon]}},
+            {"$set": {"favorite": True}},
         )
 
-        await ctx.send(f"Favorited your {unfavnum} unfavorited pokemon.\nAll {num} selected pokemon are now favorited.")
+        await ctx.send(
+            f"Favorited your {unfavnum} unfavorited pokemon.\nAll {num} selected pokemon are now favorited."
+        )
 
     # Filter
     @flags.add_flag("--shiny", action="store_true")
@@ -370,10 +394,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -382,7 +406,13 @@ class Pokemon(commands.Cog):
     # Rename all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.user)
-    @flags.command(aliases=("unfavouriteall","unfavall","ufa",))
+    @flags.command(
+        aliases=(
+            "unfavouriteall",
+            "unfavall",
+            "ufa",
+        )
+    )
     async def unfavoriteall(self, ctx, **flags):
         """Mass unfavorite selected pokemon."""
 
@@ -390,7 +420,7 @@ class Pokemon(commands.Cog):
 
         if aggregations is None:
             return
-        
+
         # Check pokemon and unfavorited pokemon num
         num = await self.bot.mongo.fetch_pokemon_count(
             ctx.author, aggregations=aggregations
@@ -427,11 +457,13 @@ class Pokemon(commands.Cog):
             return await ctx.send("Time's up. Aborted.")
 
         await self.bot.mongo.db.pokemon.update_many(
-        {"_id": {"$in": [x.id async for x in pokemon]}},
-        {"$set": {"favorite": False}},
+            {"_id": {"$in": [x.id async for x in pokemon]}},
+            {"$set": {"favorite": False}},
         )
 
-        await ctx.send(f"Unfavorited your {favnum} favorited pokemon.\nAll {num} selected pokemon are now unfavorited.")
+        await ctx.send(
+            f"Unfavorited your {favnum} favorited pokemon.\nAll {num} selected pokemon are now unfavorited."
+        )
 
     @checks.has_started()
     @commands.command(aliases=("i",), rest_is_raw=True)
@@ -669,8 +701,8 @@ class Pokemon(commands.Cog):
                         {"$match": {expr: {"$gt": math.floor(ops[1])}}},
                     )
 
-        for flag, dupes in constants.FILTER_BY_DUPLICATES.items():
-            if flag in flags and flags[flag] is not None: 
+        for flag, amt in constants.FILTER_BY_DUPLICATES.items():
+            if flag in flags and flags[flag] is not None:
                 # Processing arguments
                 if len(flags[flag][0]) > 1:
                     raise commands.BadArgument(
@@ -679,26 +711,12 @@ class Pokemon(commands.Cog):
 
                 iv = int(flags[flag][0][0])
 
-                if not (0 <= iv <= 31):
-                    raise commands.BadArgument(
-                        f"IV's may only be a value between 0 and 31!"
-                    )
-
                 # Processing combinations
-                fields = []
-                combinations = []
-                for field in constants.IV_FIELDS:
-                    fields.append({field: {"$eq":iv}})
-                fields = list(itertools.combinations(fields,dupes))
-                for field in fields:
-                    combinations.append(
-                        {"$and":field}
-                    )
-                aggregations.append(
-                    {"$match":
-                        {"$or": combinations}
-                    }
-                )
+                combinations = [
+                    {field: iv for field in combo}
+                    for combo in itertools.combinations(constants.IV_FIELDS, amt)
+                ]
+                aggregations.append({"$match": {"$or": combinations}})
 
         if order_by is not None:
             s = order_by[-1]
@@ -823,10 +841,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -934,11 +952,11 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
-    
+    @flags.add_flag("--triple", "--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
@@ -1118,7 +1136,7 @@ class Pokemon(commands.Cog):
                 return embed
 
             pages = pagination.ContinuablePages(
-                pagination.FunctionPageSource(math.ceil(809/20), get_page)
+                pagination.FunctionPageSource(math.ceil(809 / 20), get_page)
             )
             pages.current_page = int(search_or_page) - 1
             self.bot.menus[ctx.author.id] = pages

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -3,6 +3,7 @@ import asyncio
 import math
 import re
 import typing
+import itertools
 from datetime import datetime
 from operator import itemgetter
 from discord.errors import DiscordException
@@ -116,6 +117,12 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--spdefiv", nargs="+", action="append")
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
+
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -275,6 +282,12 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
 
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
@@ -355,6 +368,12 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--spdefiv", nargs="+", action="append")
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
+
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -650,6 +669,37 @@ class Pokemon(commands.Cog):
                         {"$match": {expr: {"$gt": math.floor(ops[1])}}},
                     )
 
+        for flag, dupes in constants.FILTER_BY_DUPLICATES.items():
+            if flag in flags and flags[flag] is not None: 
+                # Processing arguments
+                if len(flags[flag][0]) > 1:
+                    raise commands.BadArgument(
+                        f"`--{flag}` can't parse more than 1 argument!"
+                    )
+
+                iv = int(flags[flag][0][0])
+
+                if not (0 <= iv <= 31):
+                    raise commands.BadArgument(
+                        f"IV's may only be a value between 0 and 31!"
+                    )
+
+                # Processing combinations
+                fields = []
+                combinations = []
+                for field in constants.IV_FIELDS:
+                    fields.append({field: {"$eq":iv}})
+                fields = list(itertools.combinations(fields,dupes))
+                for field in fields:
+                    combinations.append(
+                        {"$and":field}
+                    )
+                aggregations.append(
+                    {"$match":
+                        {"$or": combinations}
+                    }
+                )
+
         if order_by is not None:
             s = order_by[-1]
             if order_by[-1] in "+-":
@@ -772,6 +822,12 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
 
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
@@ -877,6 +933,12 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
 
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -119,10 +119,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple", "--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -297,10 +297,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple", "--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -394,10 +394,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple", "--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -709,7 +709,7 @@ class Pokemon(commands.Cog):
                         f"`--{flag}` can't parse more than 1 argument!"
                     )
 
-                iv = int(flags[flag][0][0])
+                iv = int(flags[flag])
 
                 # Processing combinations
                 combinations = [
@@ -841,10 +841,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple", "--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
@@ -952,10 +952,10 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple", "--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple", "--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -578,15 +578,15 @@ class Trading(commands.Cog):
     @flags.add_flag("--iv", nargs="+", action="append")
 
     # Duplicate IV's
-    @flags.add_flag("--triple","--three", nargs="+", action="append")
-    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
-    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
-    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+    @flags.add_flag("--triple", "--three", nargs="?")
+    @flags.add_flag("--quadruple", "--four", nargs="?")
+    @flags.add_flag("--pentuple", "--quintuple", "--five", nargs="?")
+    @flags.add_flag("--hextuple", "--sextuple", "--six", nargs="?")
 
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
-    
+
     # Trade add all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.member)

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -566,6 +566,7 @@ class Trading(commands.Cog):
     @flags.add_flag("--name", "--n", nargs="+", action="append")
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", type=str, action="append")
+
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")
@@ -575,9 +576,17 @@ class Trading(commands.Cog):
     @flags.add_flag("--spdefiv", nargs="+", action="append")
     @flags.add_flag("--spdiv", nargs="+", action="append")
     @flags.add_flag("--iv", nargs="+", action="append")
+
+    # Duplicate IV's
+    @flags.add_flag("--triple","--three", nargs="+", action="append")
+    @flags.add_flag("--quadruple","--four", nargs="+", action="append")
+    @flags.add_flag("--pentuple","--quintuple","--five", nargs="+", action="append")
+    @flags.add_flag("--hextuple","--sextuple","--six", nargs="+", action="append")
+
     # Skip/limit
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
+    
     # Trade add all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.member)

--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -150,6 +150,22 @@ FILTER_BY_NUMERICAL = {
     "spdiv": "pokemon.iv_spd",
 }
 
+FILTER_BY_DUPLICATES = {
+    "triple": 3,
+    "quadruple": 4,
+    "pentuple": 5,
+    "hextuple": 6,
+}
+
+IV_FIELDS = [
+    "pokemon.iv_hp",
+    "pokemon.iv_atk",
+    "pokemon.iv_defn",
+    "pokemon.iv_satk",
+    "pokemon.iv_sdef",
+    "pokemon.iv_spd",
+]
+
 NATURE_MULTIPLIERS = {
     "Hardy": {
         "hp": 1,


### PR DESCRIPTION
**Changes**
1. Added Filters for Pokemon with IV Duplicates
**Filter Signature:**
`--<filter> <iv>`
Now, you may use `--triple`, `--quadruple`,`--quintuple`, and `--hextuple`, to filter your searches! Detailed examples given below.
2. Added Filter Nicknames
a. `--triple` may also be called by `--three`
b. `--quadruple` may also be called by `--four`
c. `--quintuple` may also be called by `--pentuple` and `--five`
d. `--hextuple` may also be called by `--six`
3. List of Commands Affected
a. `p!p`, `p!nickall`, `p!favoriteall`, `p!unfavoriteall`,`p!releaseall`
b. `p!auction search`
c. `p!market search`
d. `p!trade addall`

**Example**
1.  For example, you have 3 Pokemon in your inventory of the following IV's
Pokemon 1: IV's {15, 15, 13, 14, 15, 15}
Pokemon 2: IV's {15, 15, 13, 15, 20, 10}
Pokemon 3: IV's {10, 10, 10, 10, 10, 10}
2. Using `p!p --triple 15`
Would return Pokemon 1 and 2
3. Using `p!p --quadruple 15`
Would return Pokemon 1
4. Using `p!p --quintuple 10`
Would return Pokemon 3
5. Using `p!p --triple 31`
Would return no Pokemon.