### PR TITLE
Enhanced: Details in Bid and Un/Favoriteall

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -473,7 +473,7 @@ class Auctions(commands.Cog):
                 self.bot.loop.create_task(
                     await self.bot.http.send_message(
                         priv["id"],
-                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** (Auction #{auction.id}).",
+                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** (Auction #{auction.id}).\nCurrent Bid: **{bid:,} Pokécoins**.",
                     )
                 )
             self.bot.loop.create_task(

--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -473,7 +473,7 @@ class Auctions(commands.Cog):
                 self.bot.loop.create_task(
                     await self.bot.http.send_message(
                         priv["id"],
-                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** (Auction #{auction.id}).\nCurrent Bid: **{bid:,} Pokécoins**.",
+                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** (Auction #{auction.id}).",
                     )
                 )
             self.bot.loop.create_task(

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -320,7 +320,7 @@ class Pokemon(commands.Cog):
         try:
             msg = await self.bot.wait_for("message", timeout=30, check=check)
 
-            if msg.content.lower() != f"confirm favorite {unfavnum}":
+            if msg.content.lower() not in [f"confirm favorite {unfavnum}",f"confirm favourite {unfavnum}"]:
                 return await ctx.send("Aborted.")
 
         except asyncio.TimeoutError:
@@ -401,7 +401,7 @@ class Pokemon(commands.Cog):
         try:
             msg = await self.bot.wait_for("message", timeout=30, check=check)
 
-            if msg.content.lower() != f"confirm unfavorite {favnum}":
+            if msg.content.lower() not in [f"confirm unfavorite {favnum}",f"confirm unfavourite {favnum}"]:
                 return await ctx.send("Aborted.")
 
         except asyncio.TimeoutError:


### PR DESCRIPTION
**Enhanced:**
Auction Overbid DM Notification - Added `Current Bid: (x) Pokecoins.`

**Added:**
Spelling Support for word "favorite/favourite" in Un/Favoriteall confirmations.